### PR TITLE
Add Random[F] capability trait

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 This is the first release for a stable Scala 3 version!
 
-### New Scala versions:
+### new features
+- add `busymachines.pureharm.capabilities.Random[F]` capability trait. Use this for your randomness needs, including UUID generation
+
+### new Scala versions:
 - `2.13.6`
 - `3.0.1` for JVM + JS platforms
 - drop `3.0.0-RC2`, `3.0.0-RC3`

--- a/effects-cats/js/src/main/scala/busymachines/pureharm/capabilities/PlatformSpecificRandom.scala
+++ b/effects-cats/js/src/main/scala/busymachines/pureharm/capabilities/PlatformSpecificRandom.scala
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2019 BusyMachines
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package busymachines.pureharm.capabilities
+
+// we have no secure random on JS
+trait PlatformSpecificRandom {}

--- a/effects-cats/jvm/src/main/scala/busymachines/pureharm/capabilities/PlatformSpecificRandom.scala
+++ b/effects-cats/jvm/src/main/scala/busymachines/pureharm/capabilities/PlatformSpecificRandom.scala
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2019 BusyMachines
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package busymachines.pureharm.capabilities
+
+import scala.util.{Random => ScalaRandom}
+
+import busymachines.pureharm.effects._
+import cats.syntax.all._
+
+trait PlatformSpecificRandom {
+
+  /** Provides a Random[F] instance backed up by a java.util.security.SecureRandom()
+    *
+    * Available only on JVM, JS does not have secure random.
+    */
+  def secureRandom[F[_]](implicit F: Sync[F]): Random[F] = new RandomImpl[F] {
+
+    override protected val randomF: F[ScalaRandom] = {
+      for {
+        javaTLR <- F.delay(new java.security.SecureRandom)
+      } yield new ScalaRandom(javaTLR)
+    }
+  }
+}

--- a/effects-cats/shared/src/main/scala/busymachines/pureharm/capabilities/Random.scala
+++ b/effects-cats/shared/src/main/scala/busymachines/pureharm/capabilities/Random.scala
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2019 BusyMachines
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package busymachines.pureharm.capabilities
+
+import java.util.UUID
+import scala.util.{Random => ScalaRandom}
+
+import busymachines.pureharm.effects._
+import cats.syntax.all._
+
+trait Random[F[_]] {
+  def boolean: F[Boolean]
+
+  def int: F[Int]
+  def int(l: Int): F[Int]
+  def int(l: Int, h: Int): F[Int]
+
+  def long: F[Long]
+  def long(l: Long): F[Long]
+  def long(l: Long, h: Long): F[Long]
+
+  def double(l: Double): F[Double]
+
+  def double(l: Double, h: Double): F[Double]
+
+  def string(maxSize: Int): F[String]
+
+  def uuid: F[UUID]
+
+  final def mapK[G[_]](fk: F ~> G): Random[G] = new Random[G] {
+    override def boolean: G[Boolean] = fk(Random.this.boolean)
+
+    override def int: G[Int] = fk(Random.this.int)
+
+    override def int(l: Int): G[Int] = fk(Random.this.int(l))
+
+    override def int(l: Int, h: Int): G[Int] = fk(Random.this.int(l, h))
+
+    override def long: G[Long] = fk(Random.this.long)
+
+    override def long(l: Long): G[Long] = fk(Random.this.long(l))
+
+    override def long(l: Long, h: Long): G[Long] = fk(Random.this.long(l, h))
+
+    override def double(l: Double): G[Double] = fk(Random.this.double(l))
+
+    override def double(l: Double, h: Double): G[Double] = fk(Random.this.double(l, h))
+
+    override def string(maxSize: Int): G[String] = fk(Random.this.string(maxSize))
+
+    /** Generates a Version 4 UUID
+      */
+    override def uuid: G[UUID] = fk(Random.this.uuid)
+  }
+}
+
+object Random extends PlatformSpecificRandom {
+
+  def apply[F[_]](implicit r: Random[F]): Random[F] = r
+
+  def resource[F[_]](implicit F: Sync[F]): Resource[F, Random[F]] = Resource.pure[F, Random[F]](threadLocalRandom[F])
+
+  /** Provides a Random[F] instance backed up by java.util.concurrent.ThreadLocalRandom.current()
+    *
+    * This reduces contention on the same random instance in a concurrent setting.
+    */
+  def threadLocalRandom[F[_]](implicit F: Sync[F]): Random[F] = new RandomImpl[F] {
+
+    override protected val randomF: F[ScalaRandom] = {
+      for {
+        javaTLR <- F.delay(java.util.concurrent.ThreadLocalRandom.current())
+      } yield new ScalaRandom(javaTLR)
+    }
+  }
+
+  implicit def randomForResource[F[_]: Applicative](implicit random: Random[F]): Random[Resource[F, *]] =
+    random.mapK(Resource.liftK[F])
+
+}

--- a/effects-cats/shared/src/main/scala/busymachines/pureharm/capabilities/RandomImpl.scala
+++ b/effects-cats/shared/src/main/scala/busymachines/pureharm/capabilities/RandomImpl.scala
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2019 BusyMachines
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package busymachines.pureharm.capabilities
+
+import java.util.UUID
+import scala.util.{Random => ScalaRandom}
+
+import busymachines.pureharm.anomaly._
+import busymachines.pureharm.effects._
+import cats.syntax.all._
+
+abstract class RandomImpl[F[_]](implicit F: Sync[F]) extends Random[F] {
+
+  protected def randomF: F[ScalaRandom]
+
+  protected def delay[A](f: ScalaRandom => A): F[A] = randomF.flatMap(sr => F.delay(f(sr)))
+
+  override def boolean: F[Boolean] = delay(_.nextBoolean())
+
+  override def int: F[Int] = delay(_.nextInt())
+  override def int(i: Int): F[Int] = delay(_.nextInt(i.max(1)))
+
+  override def int(l: Int, h: Int): F[Int] = for {
+    _ <-
+      if (l > h) InvalidInputAnomaly(s"Random.int(l: Int, h: Int) - l < h, but l=$l, h=$h").raiseError[F, Unit]
+      else F.unit
+    diff = h - l
+    lower <- int(diff)
+  } yield lower + diff
+
+  override def long: F[Long] = delay(_.nextLong())
+
+  override def long(l: Long): F[Long] = delay(_.nextLong(l.max(1L)))
+
+  override def long(l: Long, h: Long): F[Long] = for {
+    _ <-
+      if (l > h) InvalidInputAnomaly(s"Random.long(l: Int, h: Int) - l < h, but l=$l, h=$h").raiseError[F, Unit]
+      else F.unit
+    diff = h - l
+    lower <- long(diff)
+  } yield lower + diff
+
+  override def double(h: Double): F[Double] = this.double(0.0d, h)
+  override def double(l: Double, h: Double): F[Double] = delay(_.between(l, h))
+
+  override def string(length: Int): F[String] =
+    delay(sr => List.range(0, length).map(_ => sr.nextPrintableChar()).mkString)
+
+  // see point 2 of the procedure:
+  //  https://www.cryptosys.net/pki/uuid-rfc4122.html#note1
+  // Adjust certain bits according to RFC 4122 section 4.4 as follows:
+  //    1. set the four most significant bits of the 7th byte to 0100'B, so the high nibble is "4"
+  private[this] val clearBits49_52: Long = ~((1L << 49L) | (1L << 50L) | (1L << 51L) | (1L << 52L))
+  private[this] val setBits49_52:   Long = 1L << 50L
+
+  /* the ninth byte is the 1st byte of the most significant Long :)
+   *
+   * 2. set the two most significant bits of the 9th byte to 10'B, so the high nibble will be one of "8", "9", "A", or "B" (see Note 1).
+   */
+  private[this] val clearBits79_80: Long = ~((1L << 15L) | (1L << 16L))
+  private[this] val setBits79_80:   Long = 1L << 15L
+
+  override def uuid: F[UUID] = delay { sr =>
+    new java.util.UUID(
+      (sr.nextLong() & clearBits79_80) ^ setBits79_80, //most significant bits
+      (sr.nextLong() & clearBits49_52) ^ setBits49_52, //least significant bits
+    )
+  }
+}

--- a/effects-cats/shared/src/main/scala/busymachines/pureharm/effects/aliases/PureharmEffectsTypeDefinitions.scala
+++ b/effects-cats/shared/src/main/scala/busymachines/pureharm/effects/aliases/PureharmEffectsTypeDefinitions.scala
@@ -71,4 +71,7 @@ trait PureharmEffectsTypeDefinitions {
 
   type PureharmIOApp = busymachines.pureharm.effects.PureharmIOApp
 
+  type Random[F[_]] = busymachines.pureharm.capabilities.Random[F]
+  val Random: busymachines.pureharm.capabilities.Random.type = busymachines.pureharm.capabilities.Random
+
 }

--- a/effects-cats/shared/src/test/scala/busymachines/pureharm/effects/test/PureharmRandomTest.scala
+++ b/effects-cats/shared/src/test/scala/busymachines/pureharm/effects/test/PureharmRandomTest.scala
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2019 BusyMachines
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package busymachines.pureharm.effects.test
+
+import busymachines.pureharm.effects._
+import munit.CatsEffectSuite
+import busymachines.pureharm.capabilities.Random
+
+final class PureharmRandomTest extends CatsEffectSuite {
+
+  test("generate distinct random UUIDs") {
+    val random = Random.threadLocalRandom[IO]
+    for {
+      uuid1 <- random.uuid
+      uuid2 <- random.uuid
+      _     <- IO(assert(uuid1 != uuid2))
+    } yield ()
+  }
+}


### PR DESCRIPTION
Capability trait to be used instead of passing along the powerful `Sync` constraint.

```scala
  test("generate distinct random UUIDs") {
    val random = Random.threadLocalRandom[IO]
    for {
      uuid1 <- random.uuid
      uuid2 <- random.uuid
      _     <- IO(assert(uuid1 != uuid2))
    } yield ()
  }
```