### PR TITLE
Integrate cats-retry

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -54,7 +54,7 @@ align = most
 align.openParenCallSite = false
 align.openParenDefnSite = false
 align.multiline = true
-align.tokens.add = [
+align.tokens."+" = [
 
   {code = "<-", owner = "Enumerator.Generator"},
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ This is the first release for a stable Scala 3 version!
 - add `busymachines.pureharm.capabilities.Random[F]` capability trait. Use this for your randomness needs, including UUID generation. It is source compatible w/ the version provided in the `pureharm-effects-cats`, and the cats-effect 3 version.
 
 ### pureharm-effects-cats
-- first compatible module w/ cats-effect 3!
+- first compatible module w/ cats-effect `3.2.1`!
     - removed PureharmIOApp, you can safely use IOApp, ResourceApp, and kin from cats-effect.
     - removed `BlockingShifter`, sinice ContextShift, and Blocker are both gone from cats-effect
     - removed `ExecutionContextMT`, since it existed solely for the purpose of instantiating a good pool from main. With cats-effect 3 it's almost impossible to give a good replacement, so just rely on the default compute pool of cats-effect 3, it's really good!

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,8 +19,9 @@ This is the first release for a stable Scala 3 version!
 ### new features
 
 #### pureharm-effects-cats-2
-- inline [cats-retry](https://github.com/cb372/cats-retry/releases/tag/v3.0.0)! and provide infix syntax support. We inlined because cats-retry does not have Scala 3 support yet!
+- inline [cats-retry](https://github.com/cb372/cats-retry/releases/tag/v3.0.0)! and provide infix syntax support. We inlined because cats-retry does not have Scala 3 support yet.
 - deprecate all previous .reattempt, and .timedReattempt syntax in favor of things inlined from cats-retry
+- add `.timed : F[FiniteDuration]` (backport from cats-effect 3), and `.timedIn(t: TimeUnit): F[FiniteDuration]` syntax
 - add `busymachines.pureharm.capabilities.Random[F]` capability trait. Use this for your randomness needs, including UUID generation. It is source compatible w/ the version provided in the `pureharm-effects-cats`, and the cats-effect 3 version.
 
 ### pureharm-effects-cats
@@ -28,7 +29,8 @@ This is the first release for a stable Scala 3 version!
     - removed PureharmIOApp, you can safely use IOApp, ResourceApp, and kin from cats-effect.
     - removed `BlockingShifter`, sinice ContextShift, and Blocker are both gone from cats-effect
     - removed `ExecutionContextMT`, since it existed solely for the purpose of instantiating a good pool from main. With cats-effect 3 it's almost impossible to give a good replacement, so just rely on the default compute pool of cats-effect 3, it's really good!
-- inline [cats-retry](https://github.com/cb372/cats-retry/releases/tag/v3.0.0)! and provide infix syntax support. We inlined because cats-retry does not have Scala 3 support yet!
+- inline [cats-retry](https://github.com/cb372/cats-retry/releases/tag/v3.0.0)! and provide infix syntax support. We inlined because cats-retry does not have Scala 3 support yet.
+- add `.timedIn(t: TimeUnit): F[FiniteDuration]` syntax
 - deprecate all previous .reattempt, and .timedReattempt syntax in favor of things inlined from cats-retry
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,13 +19,17 @@ This is the first release for a stable Scala 3 version!
 ### new features
 
 #### pureharm-effects-cats-2
+- inline [cats-retry](https://github.com/cb372/cats-retry/releases/tag/v3.0.0)! and provide infix syntax support. We inlined because cats-retry does not have Scala 3 support yet!
+- deprecate all previous .reattempt, and .timedReattempt syntax in favor of things inlined from cats-retry
 - add `busymachines.pureharm.capabilities.Random[F]` capability trait. Use this for your randomness needs, including UUID generation. It is source compatible w/ the version provided in the `pureharm-effects-cats`, and the cats-effect 3 version.
 
 ### pureharm-effects-cats
 - first compatible module w/ cats-effect 3!
-- removed PureharmIOApp, you can safely use IOApp, ResourceApp, and kin from cats-effect.
-- removed `BlockingShifter`, sinice ContextShift, and Blocker are both gone from cats-effect
-- removed `ExecutionContextMT`, since it existed solely for the purpose of instantiating a good pool from main. With cats-effect 3 it's almost impossible to give a good replacement, so just rely on the default compute pool of cats-effect 3, it's really good!
+    - removed PureharmIOApp, you can safely use IOApp, ResourceApp, and kin from cats-effect.
+    - removed `BlockingShifter`, sinice ContextShift, and Blocker are both gone from cats-effect
+    - removed `ExecutionContextMT`, since it existed solely for the purpose of instantiating a good pool from main. With cats-effect 3 it's almost impossible to give a good replacement, so just rely on the default compute pool of cats-effect 3, it's really good!
+- inline [cats-retry](https://github.com/cb372/cats-retry/releases/tag/v3.0.0)! and provide infix syntax support. We inlined because cats-retry does not have Scala 3 support yet!
+- deprecate all previous .reattempt, and .timedReattempt syntax in favor of things inlined from cats-retry
 
 
 ### new Scala versions:

--- a/build.sbt
+++ b/build.sbt
@@ -114,7 +114,8 @@ lazy val root = project
 
 lazy val `effects-cats` = crossProject(JVMPlatform, JSPlatform)
   .settings(
-    scalacOptions ++= scalaCompilerOptions(scalaVersion.value)
+    scalacOptions ++= scalaCompilerOptions(scalaVersion.value),
+    headerSources / excludeFilter := HiddenFileFilter || inlinedCatsRetryFiles,
   )
   .jsSettings(
     scalaJSLinkerConfig ~= (_.withModuleKind(ModuleKind.CommonJSModule))
@@ -142,7 +143,7 @@ lazy val `effects-catsJS` = `effects-cats`.js
 lazy val `effects-cats-2` = crossProject(JVMPlatform, JSPlatform)
   .settings(
     scalacOptions ++= scalaCompilerOptions(scalaVersion.value),
-    headerSources / excludeFilter := HiddenFileFilter || "*RandomImpl.scala" || "*Random.scala",
+    headerSources / excludeFilter := HiddenFileFilter || inlinedCatsRetryFiles || "*RandomImpl.scala" || "*Random.scala",
   )
   .jsSettings(
     scalaJSLinkerConfig ~= (_.withModuleKind(ModuleKind.CommonJSModule))
@@ -170,6 +171,16 @@ lazy val `effects-cats-2JS` = `effects-cats-2`.js
 //=============================================================================
 //================================= Settings ==================================
 //=============================================================================
+
+def inlinedCatsRetryFiles: FileFilter =
+  "*package.scala" ||
+    "*Fibonacci.scala" ||
+    "*PolicyDecision.scala" ||
+    "*RetryDetails.scala" ||
+    "*RetryPolicies.scala" ||
+    "*RetryPolicy.scala" ||
+    "*RetryStatus.scala" ||
+    "*Sleep.scala"
 
 def scalaCompilerOptions(scalaVersion: String): Seq[String] =
   CrossVersion.partialVersion(scalaVersion) match {

--- a/build.sbt
+++ b/build.sbt
@@ -86,7 +86,7 @@ ThisBuild / resolvers += Resolver.sonatypeRepo("snapshots")
 
 // format: off
 val catsV            = "2.6.1"       //https://github.com/typelevel/cats/releases
-val catsEffectV      = "3.2.0"       //https://github.com/typelevel/cats-effect/releases
+val catsEffectV      = "3.2.1"       //https://github.com/typelevel/cats-effect/releases
 val catsEffect2V     = "2.5.2"       //https://github.com/typelevel/cats-effect/releases
 val fs2V             = "3.0.6"       //https://github.com/typelevel/fs2/releases
 val fs22V            = "2.5.9"       //https://github.com/typelevel/fs2/releases

--- a/effects-cats-2/shared/src/main/scala/busymachines/pureharm/effects/aliases/RetryAliases.scala
+++ b/effects-cats-2/shared/src/main/scala/busymachines/pureharm/effects/aliases/RetryAliases.scala
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2019 BusyMachines
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package busymachines.pureharm.effects.aliases
+
+trait RetryAliases {
+  type PolicyDecision = busymachines.pureharm.retry.PolicyDecision
+  val PolicyDecision: busymachines.pureharm.retry.PolicyDecision.type = busymachines.pureharm.retry.PolicyDecision
+
+  type RetryPolicy[M[_]] = busymachines.pureharm.retry.RetryPolicy[M]
+  val RetryPolicy: busymachines.pureharm.retry.RetryPolicy.type = busymachines.pureharm.retry.RetryPolicy
+
+  val RetryPolicies: busymachines.pureharm.retry.RetryPolicies.type = busymachines.pureharm.retry.RetryPolicies
+
+  type RetryStatus = busymachines.pureharm.retry.RetryStatus
+  val RetryStatus: busymachines.pureharm.retry.RetryStatus.type = busymachines.pureharm.retry.RetryStatus
+
+  type RetryDetails = busymachines.pureharm.retry.RetryDetails
+  val RetryDetails: busymachines.pureharm.retry.RetryDetails.type = busymachines.pureharm.retry.RetryDetails
+
+  type Sleep[M[_]] = busymachines.pureharm.retry.Sleep[M]
+  val Sleep: busymachines.pureharm.retry.Sleep.type = busymachines.pureharm.retry.Sleep
+}

--- a/effects-cats-2/shared/src/main/scala/busymachines/pureharm/effects/internals/PureharmSyntax.scala
+++ b/effects-cats-2/shared/src/main/scala/busymachines/pureharm/effects/internals/PureharmSyntax.scala
@@ -467,7 +467,7 @@ object PureharmSyntax {
       * @return
       *   Never fails and captures the failure of the ``fa`` within the Attempt, times both success and failure case.
       */
-    @scala.deprecated("Use a combination of attempt + .timed", "0.5.0")
+    @scala.deprecated("Use .attempt.timedIn(TimeUnit), or .attempt.timed to default to nanoseconds", "0.5.0")
     def timedAttempt(
       unit:       TimeUnit = MILLISECONDS
     )(implicit F: MonadThrow[F], timer: Timer[F]): F[(FiniteDuration, Attempt[A])] =
@@ -487,7 +487,10 @@ object PureharmSyntax {
       *   Never fails and captures the failure of the ``fa`` within the Attempt, times all successes and failures, and
       *   returns their sum. N.B. It only captures the latest failure, if it encounters one.
       */
-    @scala.deprecated("Use a combination of cats-retry + .timed from cats-effect", "0.5.0")
+    @scala.deprecated(
+      "Use .retryingOnAllErrors(...).attempt.timedIn(TimeUnit), or retryingOnAllErrors(...).attempt.timed to default to nanoseconds. N.B there exists more retry methods now, where you can specify which errors to recover from. See cats-retry documentation",
+      "0.5.0",
+    )
     def timedReattempt(
       errorLog:       (Throwable, String) => F[Unit],
       timeUnit:       TimeUnit,
@@ -502,7 +505,10 @@ object PureharmSyntax {
 
     /** Same as overload timedReattempt, but does not report any failures.
       */
-    @scala.deprecated("Use a combination of cats-retry + .timed from cats-effect", "0.5.0")
+    @scala.deprecated(
+      "Use .retryingOnAllErrors(...).attempt.timedIn(TimeUnit), or retryingOnAllErrors(...).attempt.timed to default to nanoseconds. N.B there exists more retry methods now, where you can specify which errors to recover from. See cats-retry documentation",
+      "0.5.0",
+    )
     def timedReattempt(
       timeUnit:       TimeUnit
     )(
@@ -526,7 +532,10 @@ object PureharmSyntax {
       * @return
       *   N.B. It only captures the latest failure, if it encounters one.
       */
-    @scala.deprecated("Use retry from cats-retry", "0.5.0")
+    @scala.deprecated(
+      "Use .retryingOnAllErrors(...).attempt. N.B there exists more retry methods now, where you can specify which errors to recover from. See cats-retry documentation",
+      "0.5.0",
+    )
     def reattempt(
       errorLog:       (Throwable, String) => F[Unit]
     )(
@@ -540,7 +549,10 @@ object PureharmSyntax {
 
     /** Same semantics as overload reattempt but does not report any error
       */
-    @scala.deprecated("Use a combination of attempt + .timed from cats-effect", "0.5.0")
+    @scala.deprecated(
+      "Use .retryingOnAllErrors(...).attempt. N.B there exists more retry methods now, where you can specify which errors to recover from. See cats-retry documentation",
+      "0.5.0",
+    )
     def reattempt(
       retries:        Int,
       betweenRetries: FiniteDuration,
@@ -561,7 +573,7 @@ object PureharmSyntax {
       * @return
       *   Never fails and captures the failure of the ``fa`` within the Attempt, times both success and failure case.
       */
-    @scala.deprecated("Use a combination of attempt + .timed from cats-effect", "0.5.0")
+    @scala.deprecated("Use .attempt.timedIn(TimeUnit), or .attempt.timed to default to nanoseconds", "0.5.0")
     def timedAttempt[F[_], A](
       timeUnit:   TimeUnit
     )(
@@ -587,7 +599,10 @@ object PureharmSyntax {
       *   Never fails and captures the failure of the ``fa`` within the Attempt, times all successes and failures, and
       *   returns their sum. N.B. It only captures the latest failure, if it encounters one.
       */
-    @scala.deprecated("Use a combination of cats-retry + .timed from cats-effect", "0.5.0")
+    @scala.deprecated(
+      "Use .retryingOnAllErrors(...).attempt.timedIn(TimeUnit), or retryingOnAllErrors(...).attempt.timed to default to nanoseconds. N.B there exists more retry methods now, where you can specify which errors to recover from. See cats-retry documentation",
+      "0.5.0",
+    )
     def timedReattempt[F[_]: MonadThrow: Timer, A](
       errorLog:       (Throwable, String) => F[Unit],
       timeUnit:       TimeUnit,
@@ -635,7 +650,10 @@ object PureharmSyntax {
       * @return
       *   N.B. It only captures the latest failure, if it encounters one.
       */
-    @scala.deprecated("Use a cats-retry", "0.5.0")
+    @scala.deprecated(
+      "Use .retryingOnAllErrors(...).attempt, or retryingOnAllErrors(...).attempt. N.B there exists more retry methods now, where you can specify which errors to recover from. See cats-retry documentation",
+      "0.5.0",
+    )
     def reattempt[F[_]: MonadThrow: Timer, A](
       errorLog:       (Throwable, String) => F[Unit]
     )(
@@ -648,7 +666,7 @@ object PureharmSyntax {
 
     /** Same semantics as overload reattempt but does not report any error
       */
-    @scala.deprecated("Use a cats-retry", "0.5.0")
+    @scala.deprecated("Use .retryingOnFailures", "0.5.0")
     def reattempt[F[_]: MonadThrow: Timer, A](
       retries:        Int,
       betweenRetries: FiniteDuration,

--- a/effects-cats-2/shared/src/main/scala/busymachines/pureharm/retry/Fibonacci.scala
+++ b/effects-cats-2/shared/src/main/scala/busymachines/pureharm/retry/Fibonacci.scala
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2021 Chris Birchall et. co, contributors of cats-retry
+ * https://github.com/cb372/cats-retry
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package busymachines.pureharm.retry
+
+object Fibonacci {
+
+  def fibonacci(n: Int): Long =
+    if (n > 0)
+      fib(n)._1
+    else
+      0
+
+  // "Fast doubling" Fibonacci algorithm.
+  // See e.g. http://funloop.org/post/2017-04-14-computing-fibonacci-numbers.html for explanation.
+  private def fib(n: Int): (Long, Long) = n match {
+    case 0 => (0, 1)
+    case m =>
+      val (a, b) = fib(m / 2)
+      val c      = a * (b * 2 - a)
+      val d      = a * a + b * b
+      if (n % 2 == 0)
+        (c, d)
+      else
+        (d, c + d)
+  }
+}

--- a/effects-cats-2/shared/src/main/scala/busymachines/pureharm/retry/PolicyDecision.scala
+++ b/effects-cats-2/shared/src/main/scala/busymachines/pureharm/retry/PolicyDecision.scala
@@ -1,5 +1,6 @@
 /*
- * Copyright 2019 BusyMachines
+ * Copyright 2021 Chris Birchall et. co, contributors of cats-retry
+ * https://github.com/cb372/cats-retry
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,17 +14,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package busymachines.pureharm.retry
 
-package busymachines.pureharm.effects
+import scala.concurrent.duration.FiniteDuration
 
-import busymachines.pureharm.effects.aliases
+sealed trait PolicyDecision
 
-// format: off
-trait PureharmEffectsAliases
-  extends aliases.PureharmEffectsTypeDefinitions
-  with aliases.CatsAliases
-  with aliases.ScalaStdAliases
-  with aliases.CatsEffectAliases
-  with aliases.Fs2Aliases
-  with aliases.RetryAliases
-// format: on
+object PolicyDecision {
+  case object GiveUp extends PolicyDecision
+
+  final case class DelayAndRetry(
+    delay: FiniteDuration
+  ) extends PolicyDecision
+}

--- a/effects-cats-2/shared/src/main/scala/busymachines/pureharm/retry/RetryDetails.scala
+++ b/effects-cats-2/shared/src/main/scala/busymachines/pureharm/retry/RetryDetails.scala
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2021 Chris Birchall et. co, contributors of cats-retry
+ * https://github.com/cb372/cats-retry
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package busymachines.pureharm.retry
+
+import scala.concurrent.duration.FiniteDuration
+
+sealed trait RetryDetails {
+  def retriesSoFar:    Int
+  def cumulativeDelay: FiniteDuration
+  def givingUp:        Boolean
+  def upcomingDelay:   Option[FiniteDuration]
+}
+
+object RetryDetails {
+
+  final case class GivingUp(
+    totalRetries: Int,
+    totalDelay:   FiniteDuration,
+  ) extends RetryDetails {
+    val retriesSoFar:    Int                    = totalRetries
+    val cumulativeDelay: FiniteDuration         = totalDelay
+    val givingUp:        Boolean                = true
+    val upcomingDelay:   Option[FiniteDuration] = None
+  }
+
+  final case class WillDelayAndRetry(
+    nextDelay:       FiniteDuration,
+    retriesSoFar:    Int,
+    cumulativeDelay: FiniteDuration,
+  ) extends RetryDetails {
+    val givingUp:      Boolean                = false
+    val upcomingDelay: Option[FiniteDuration] = Some(nextDelay)
+  }
+}

--- a/effects-cats-2/shared/src/main/scala/busymachines/pureharm/retry/RetryPolicies.scala
+++ b/effects-cats-2/shared/src/main/scala/busymachines/pureharm/retry/RetryPolicies.scala
@@ -1,0 +1,170 @@
+/*
+ * Copyright 2021 Chris Birchall et. co, contributors of cats-retry
+ * https://github.com/cb372/cats-retry
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package busymachines.pureharm.retry
+
+import java.util.concurrent.TimeUnit
+
+import cats.Applicative
+import cats.syntax.functor._
+import cats.syntax.show._
+import busymachines.pureharm.retry.PolicyDecision._
+
+import scala.concurrent.duration.{Duration, FiniteDuration}
+import scala.util.Random
+
+object RetryPolicies {
+  private val LongMax: BigInt = BigInt(Long.MaxValue)
+
+  /*
+   * Multiply the given duration by the given multiplier, but cap the result to
+   * ensure we don't try to create a FiniteDuration longer than 2^63 - 1 nanoseconds.
+   *
+   * Note: despite the "safe" in the name, we can still create an invalid
+   * FiniteDuration if the multiplier is negative. But an assumption of the library
+   * as a whole is that nobody would be silly enough to use negative delays.
+   */
+  private def safeMultiply(
+    duration:   FiniteDuration,
+    multiplier: Long,
+  ): FiniteDuration = {
+    val durationNanos   = BigInt(duration.toNanos)
+    val resultNanos     = durationNanos * BigInt(multiplier)
+    val safeResultNanos = resultNanos.min(LongMax)
+    FiniteDuration(safeResultNanos.toLong, TimeUnit.NANOSECONDS)
+  }
+
+  /** Don't retry at all and always give up. Only really useful for combining with other policies.
+    */
+  def alwaysGiveUp[M[_]: Applicative]: RetryPolicy[M] =
+    RetryPolicy.liftWithShow(Function.const(GiveUp), "alwaysGiveUp")
+
+  /** Delay by a constant amount before each retry. Never give up.
+    */
+  def constantDelay[M[_]: Applicative](delay: FiniteDuration): RetryPolicy[M] =
+    RetryPolicy.liftWithShow(
+      Function.const(DelayAndRetry(delay)),
+      show"constantDelay($delay)",
+    )
+
+  /** Each delay is twice as long as the previous one. Never give up.
+    */
+  def exponentialBackoff[M[_]: Applicative](
+    baseDelay: FiniteDuration
+  ): RetryPolicy[M] =
+    RetryPolicy.liftWithShow(
+      { status =>
+        val delay =
+          safeMultiply(baseDelay, Math.pow(2, status.retriesSoFar.toDouble).toLong)
+        DelayAndRetry(delay)
+      },
+      show"exponentialBackOff(baseDelay=$baseDelay)",
+    )
+
+  /** Retry without delay, giving up after the given number of retries.
+    */
+  def limitRetries[M[_]: Applicative](maxRetries: Int): RetryPolicy[M] =
+    RetryPolicy.liftWithShow(
+      status =>
+        if (status.retriesSoFar >= maxRetries) {
+          GiveUp
+        }
+        else {
+          DelayAndRetry(Duration.Zero)
+        },
+      show"limitRetries(maxRetries=$maxRetries)",
+    )
+
+  /** Delay(n) = Delay(n - 2) + Delay(n - 1)
+    *
+    * e.g. if `baseDelay` is 10 milliseconds, the delays before each retry will be 10 ms, 10 ms, 20 ms, 30ms, 50ms,
+    * 80ms, 130ms, ...
+    */
+  def fibonacciBackoff[M[_]: Applicative](
+    baseDelay: FiniteDuration
+  ): RetryPolicy[M] =
+    RetryPolicy.liftWithShow(
+      { status =>
+        val delay =
+          safeMultiply(baseDelay, Fibonacci.fibonacci(status.retriesSoFar + 1))
+        DelayAndRetry(delay)
+      },
+      show"fibonacciBackoff(baseDelay=$baseDelay)",
+    )
+
+  /** "Full jitter" backoff algorithm. See https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/
+    */
+  def fullJitter[M[_]: Applicative](baseDelay: FiniteDuration): RetryPolicy[M] =
+    RetryPolicy.liftWithShow(
+      { status =>
+        val e          = Math.pow(2, status.retriesSoFar.toDouble).toLong
+        val maxDelay   = safeMultiply(baseDelay, e)
+        val delayNanos = (maxDelay.toNanos * Random.nextDouble()).toLong
+        DelayAndRetry(new FiniteDuration(delayNanos, TimeUnit.NANOSECONDS))
+      },
+      show"fullJitter(baseDelay=$baseDelay)",
+    )
+
+  /** Set an upper bound on any individual delay produced by the given policy.
+    */
+  def capDelay[M[_]: Applicative](
+    cap:    FiniteDuration,
+    policy: RetryPolicy[M],
+  ): RetryPolicy[M] =
+    policy.meet(constantDelay(cap))
+
+  /** Add an upper bound to a policy such that once the given time-delay amount <b>per try</b> has been reached or
+    * exceeded, the policy will stop retrying and give up. If you need to stop retrying once <b>cumulative</b> delay
+    * reaches a time-delay amount, use [[limitRetriesByCumulativeDelay]].
+    */
+  def limitRetriesByDelay[M[_]: Applicative](
+    threshold: FiniteDuration,
+    policy:    RetryPolicy[M],
+  ): RetryPolicy[M] = {
+    def decideNextRetry(status: RetryStatus): M[PolicyDecision] =
+      policy.decideNextRetry(status).map {
+        case r @ DelayAndRetry(delay) =>
+          if (delay > threshold) GiveUp else r
+        case GiveUp                   => GiveUp
+      }
+
+    RetryPolicy.withShow[M](
+      decideNextRetry,
+      show"limitRetriesByDelay(threshold=$threshold, $policy)",
+    )
+  }
+
+  /** Add an upperbound to a policy such that once the cumulative delay over all retries has reached or exceeded the
+    * given limit, the policy will stop retrying and give up.
+    */
+  def limitRetriesByCumulativeDelay[M[_]: Applicative](
+    threshold: FiniteDuration,
+    policy:    RetryPolicy[M],
+  ): RetryPolicy[M] = {
+    def decideNextRetry(status: RetryStatus): M[PolicyDecision] =
+      policy.decideNextRetry(status).map {
+        case r @ DelayAndRetry(delay) =>
+          if (status.cumulativeDelay + delay >= threshold) GiveUp else r
+        case GiveUp                   => GiveUp
+      }
+
+    RetryPolicy.withShow[M](
+      decideNextRetry,
+      show"limitRetriesByCumulativeDelay(threshold=$threshold, $policy)",
+    )
+  }
+}

--- a/effects-cats-2/shared/src/main/scala/busymachines/pureharm/retry/RetryPolicy.scala
+++ b/effects-cats-2/shared/src/main/scala/busymachines/pureharm/retry/RetryPolicy.scala
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2021 Chris Birchall et. co, contributors of cats-retry
+ * https://github.com/cb372/cats-retry
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package busymachines.pureharm.retry
+
+import cats.{Apply, Applicative, Monad, Functor}
+import cats.kernel.BoundedSemilattice
+import busymachines.pureharm.retry.PolicyDecision._
+
+import scala.concurrent.duration.Duration
+import scala.concurrent.duration.FiniteDuration
+import cats.arrow.FunctionK
+import cats.implicits._
+import cats.Show
+
+case class RetryPolicy[M[_]](
+  decideNextRetry: RetryStatus => M[PolicyDecision]
+) {
+  def show: String = toString
+
+  def followedBy(rp: RetryPolicy[M])(implicit M: Apply[M]): RetryPolicy[M] =
+    RetryPolicy.withShow(
+      status =>
+        M.map2(decideNextRetry(status), rp.decideNextRetry(status)) {
+          case (GiveUp, pd) => pd
+          case (pd, _)      => pd
+        },
+      show"$show.followedBy($rp)",
+    )
+
+  /** Combine this schedule with another schedule, giving up when either of the schedules want to give up and choosing
+    * the maximum of the two delays when both of the schedules want to delay the next retry. The dual of the `meet`
+    * operation.
+    */
+  def join(rp: RetryPolicy[M])(implicit M: Apply[M]): RetryPolicy[M] =
+    RetryPolicy.withShow[M](
+      status =>
+        M.map2(decideNextRetry(status), rp.decideNextRetry(status)) {
+          case (DelayAndRetry(a), DelayAndRetry(b)) => DelayAndRetry(a.max(b))
+          case _                                    => GiveUp
+        },
+      show"$show.join($rp)",
+    )
+
+  /** Combine this schedule with another schedule, giving up when both of the schedules want to give up and choosing the
+    * minimum of the two delays when both of the schedules want to delay the next retry. The dual of the `join`
+    * operation.
+    */
+  def meet(rp: RetryPolicy[M])(implicit M: Apply[M]): RetryPolicy[M] =
+    RetryPolicy.withShow[M](
+      status =>
+        M.map2(decideNextRetry(status), rp.decideNextRetry(status)) {
+          case (DelayAndRetry(a), DelayAndRetry(b)) => DelayAndRetry(a.min(b))
+          case (s @ DelayAndRetry(_), GiveUp)       => s
+          case (GiveUp, s @ DelayAndRetry(_))       => s
+          case _                                    => GiveUp
+        },
+      show"$show.meet($rp)",
+    )
+
+  def mapDelay(
+    f:          FiniteDuration => FiniteDuration
+  )(implicit M: Functor[M]): RetryPolicy[M] =
+    RetryPolicy.withShow(
+      status =>
+        M.map(decideNextRetry(status)) {
+          case GiveUp           => GiveUp
+          case DelayAndRetry(d) => DelayAndRetry(f(d))
+        },
+      show"$show.mapDelay(<function>)",
+    )
+
+  def flatMapDelay(
+    f:          FiniteDuration => M[FiniteDuration]
+  )(implicit M: Monad[M]): RetryPolicy[M] =
+    RetryPolicy.withShow(
+      status =>
+        M.flatMap(decideNextRetry(status)) {
+          case GiveUp           => M.pure(GiveUp)
+          case DelayAndRetry(d) => M.map(f(d))(DelayAndRetry(_))
+        },
+      show"$show.flatMapDelay(<function>)",
+    )
+
+  def mapK[N[_]](nt: FunctionK[M, N]): RetryPolicy[N] =
+    RetryPolicy.withShow(
+      status => nt(decideNextRetry(status)),
+      show"$show.mapK(<FunctionK>)",
+    )
+}
+
+object RetryPolicy {
+
+  def lift[M[_]](
+    f: RetryStatus => PolicyDecision
+  )(implicit
+    M: Applicative[M]
+  ): RetryPolicy[M] =
+    RetryPolicy[M](decideNextRetry = retryStatus => M.pure(f(retryStatus)))
+
+  def withShow[M[_]](
+    decideNextRetry: RetryStatus => M[PolicyDecision],
+    pretty: => String,
+  ): RetryPolicy[M] =
+    new RetryPolicy[M](decideNextRetry) {
+      override def show:     String = pretty
+      override def toString: String = pretty
+    }
+
+  def liftWithShow[M[_]: Applicative](
+    decideNextRetry: RetryStatus => PolicyDecision,
+    pretty:          => String,
+  ): RetryPolicy[M] =
+    withShow(rs => Applicative[M].pure(decideNextRetry(rs)), pretty)
+
+  implicit def boundedSemilatticeForRetryPolicy[M[_]](implicit
+    M: Applicative[M]
+  ): BoundedSemilattice[RetryPolicy[M]] =
+    new BoundedSemilattice[RetryPolicy[M]] {
+
+      override def empty: RetryPolicy[M] =
+        RetryPolicies.constantDelay[M](Duration.Zero)
+
+      override def combine(
+        x: RetryPolicy[M],
+        y: RetryPolicy[M],
+      ): RetryPolicy[M] = x.join(y)
+    }
+
+  implicit def showForRetryPolicy[M[_]]: Show[RetryPolicy[M]] =
+    Show.show(_.show)
+}

--- a/effects-cats-2/shared/src/main/scala/busymachines/pureharm/retry/RetryStatus.scala
+++ b/effects-cats-2/shared/src/main/scala/busymachines/pureharm/retry/RetryStatus.scala
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2021 Chris Birchall et. co, contributors of cats-retry
+ * https://github.com/cb372/cats-retry
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package busymachines.pureharm.retry
+
+import scala.concurrent.duration.{Duration, FiniteDuration}
+
+final case class RetryStatus(
+  retriesSoFar:    Int,
+  cumulativeDelay: FiniteDuration,
+  previousDelay:   Option[FiniteDuration],
+) {
+
+  def addRetry(delay: FiniteDuration): RetryStatus = RetryStatus(
+    retriesSoFar    = this.retriesSoFar + 1,
+    cumulativeDelay = this.cumulativeDelay + delay,
+    previousDelay   = Some(delay),
+  )
+}
+
+object RetryStatus {
+  val NoRetriesYet = RetryStatus(0, Duration.Zero, None)
+}

--- a/effects-cats-2/shared/src/main/scala/busymachines/pureharm/retry/Sleep.scala
+++ b/effects-cats-2/shared/src/main/scala/busymachines/pureharm/retry/Sleep.scala
@@ -1,5 +1,6 @@
 /*
- * Copyright 2019 BusyMachines
+ * Copyright 2021 Chris Birchall et. co, contributors of cats-retry
+ * https://github.com/cb372/cats-retry
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,16 +15,19 @@
  * limitations under the License.
  */
 
-package busymachines.pureharm.effects
+package busymachines.pureharm.retry
 
-import busymachines.pureharm.effects.aliases
+import cats.effect.Timer
 
-// format: off
-trait PureharmEffectsAliases
-  extends aliases.PureharmEffectsTypeDefinitions
-  with aliases.CatsAliases
-  with aliases.ScalaStdAliases
-  with aliases.CatsEffectAliases
-  with aliases.Fs2Aliases
-  with aliases.RetryAliases
-// format: on
+import scala.concurrent.duration.FiniteDuration
+
+trait Sleep[M[_]] {
+  def sleep(delay: FiniteDuration): M[Unit]
+}
+
+object Sleep {
+  def apply[M[_]](implicit sleep: Sleep[M]): Sleep[M] = sleep
+
+  implicit def sleepUsingTimer[F[_]](implicit t: Timer[F]): Sleep[F] =
+    (delay: FiniteDuration) => t.sleep(delay)
+}

--- a/effects-cats-2/shared/src/main/scala/busymachines/pureharm/retry/retryOps.scala
+++ b/effects-cats-2/shared/src/main/scala/busymachines/pureharm/retry/retryOps.scala
@@ -1,0 +1,250 @@
+/*
+ * Copyright 2019 BusyMachines
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package busymachines.pureharm.retry
+
+import cats.{Monad, MonadError}
+import cats.syntax.apply._
+import cats.syntax.functor._
+import cats.syntax.flatMap._
+
+import scala.concurrent.duration.FiniteDuration
+
+object retryOps {
+  def retryingOnFailures[A] = new RetryingOnFailuresPartiallyApplied[A]
+
+  private def retryingOnFailuresImpl[M[_], A](
+    policy:        RetryPolicy[M],
+    wasSuccessful: A => M[Boolean],
+    onFailure:     (A, RetryDetails) => M[Unit],
+    status:        RetryStatus,
+    a:             A,
+  )(implicit
+    M:             Monad[M],
+    S:             Sleep[M],
+  ): M[Either[RetryStatus, A]] = {
+
+    def onFalse: M[Either[RetryStatus, A]] = for {
+      nextStep <- applyPolicy(policy, status)
+      _        <- onFailure(a, buildRetryDetails(status, nextStep))
+      result   <- nextStep match {
+        case NextStep.RetryAfterDelay(delay, updatedStatus) =>
+          S.sleep(delay) *>
+            M.pure(Left(updatedStatus)) // continue recursion
+        case NextStep.GiveUp =>
+          M.pure(Right(a)) // stop the recursion
+      }
+    } yield result
+
+    wasSuccessful(a).ifM(
+      M.pure(Right(a)), // stop the recursion
+      onFalse,
+    )
+  }
+
+  private[retry] class RetryingOnFailuresPartiallyApplied[A] {
+
+    def apply[M[_]](
+      policy:        RetryPolicy[M],
+      wasSuccessful: A => M[Boolean],
+      onFailure:     (A, RetryDetails) => M[Unit],
+    )(
+      action:        => M[A]
+    )(implicit
+      M:             Monad[M],
+      S:             Sleep[M],
+    ): M[A] = M.tailRecM(RetryStatus.NoRetriesYet) { status =>
+      action.flatMap(a => retryingOnFailuresImpl(policy, wasSuccessful, onFailure, status, a))
+    }
+  }
+
+  def retryingOnSomeErrors[A] = new RetryingOnSomeErrorsPartiallyApplied[A]
+
+  private def retryingOnSomeErrorsImpl[M[_], A, E](
+    policy:          RetryPolicy[M],
+    isWorthRetrying: E => M[Boolean],
+    onError:         (E, RetryDetails) => M[Unit],
+    status:          RetryStatus,
+    attempt:         Either[E, A],
+  )(implicit
+    ME:              MonadError[M, E],
+    S:               Sleep[M],
+  ): M[Either[RetryStatus, A]] = attempt match {
+    case Left(error)    =>
+      isWorthRetrying(error).ifM(
+        for {
+          nextStep <- applyPolicy(policy, status)
+          _        <- onError(error, buildRetryDetails(status, nextStep))
+          result   <- nextStep match {
+            case NextStep.RetryAfterDelay(delay, updatedStatus) =>
+              S.sleep(delay) *>
+                ME.pure(Left(updatedStatus)) // continue recursion
+            case NextStep.GiveUp =>
+              ME.raiseError[A](error).map(Right(_)) // stop the recursion
+          }
+        } yield result,
+        ME.raiseError[A](error).map(Right(_)), // stop the recursion
+      )
+    case Right(success) =>
+      ME.pure(Right(success)) // stop the recursion
+  }
+
+  private[retry] class RetryingOnSomeErrorsPartiallyApplied[A] {
+
+    def apply[M[_], E](
+      policy:          RetryPolicy[M],
+      isWorthRetrying: E => M[Boolean],
+      onError:         (E, RetryDetails) => M[Unit],
+    )(
+      action:          => M[A]
+    )(implicit
+      ME:              MonadError[M, E],
+      S:               Sleep[M],
+    ): M[A] = ME.tailRecM(RetryStatus.NoRetriesYet) { status =>
+      ME.attempt(action).flatMap { attempt =>
+        retryingOnSomeErrorsImpl(
+          policy,
+          isWorthRetrying,
+          onError,
+          status,
+          attempt,
+        )
+      }
+    }
+  }
+
+  def retryingOnAllErrors[A] = new RetryingOnAllErrorsPartiallyApplied[A]
+
+  private[retry] class RetryingOnAllErrorsPartiallyApplied[A] {
+
+    def apply[M[_], E](
+      policy:  RetryPolicy[M],
+      onError: (E, RetryDetails) => M[Unit],
+    )(
+      action:  => M[A]
+    )(implicit
+      ME:      MonadError[M, E],
+      S:       Sleep[M],
+    ): M[A] =
+      retryingOnSomeErrors[A].apply[M, E](policy, _ => ME.pure(true), onError)(
+        action
+      )
+  }
+
+  def retryingOnFailuresAndSomeErrors[A] =
+    new RetryingOnFailuresAndSomeErrorsPartiallyApplied[A]
+
+  private[retry] class RetryingOnFailuresAndSomeErrorsPartiallyApplied[A] {
+
+    def apply[M[_], E](
+      policy:          RetryPolicy[M],
+      wasSuccessful:   A => M[Boolean],
+      isWorthRetrying: E => M[Boolean],
+      onFailure:       (A, RetryDetails) => M[Unit],
+      onError:         (E, RetryDetails) => M[Unit],
+    )(
+      action:          => M[A]
+    )(implicit
+      ME:              MonadError[M, E],
+      S:               Sleep[M],
+    ): M[A] =
+      ME.tailRecM(RetryStatus.NoRetriesYet) { status =>
+        ME.attempt(action).flatMap {
+          case Right(a) =>
+            retryingOnFailuresImpl(policy, wasSuccessful, onFailure, status, a)
+          case attempt  =>
+            retryingOnSomeErrorsImpl(
+              policy,
+              isWorthRetrying,
+              onError,
+              status,
+              attempt,
+            )
+        }
+      }
+  }
+
+  def retryingOnFailuresAndAllErrors[A] =
+    new RetryingOnFailuresAndAllErrorsPartiallyApplied[A]
+
+  private[retry] class RetryingOnFailuresAndAllErrorsPartiallyApplied[A] {
+
+    def apply[M[_], E](
+      policy:        RetryPolicy[M],
+      wasSuccessful: A => M[Boolean],
+      onFailure:     (A, RetryDetails) => M[Unit],
+      onError:       (E, RetryDetails) => M[Unit],
+    )(
+      action:        => M[A]
+    )(implicit
+      ME:            MonadError[M, E],
+      S:             Sleep[M],
+    ): M[A] =
+      retryingOnFailuresAndSomeErrors[A]
+        .apply[M, E](
+          policy,
+          wasSuccessful,
+          _ => ME.pure(true),
+          onFailure,
+          onError,
+        )(
+          action
+        )
+  }
+
+  def noop[M[_]: Monad, A]: (A, RetryDetails) => M[Unit] =
+    (_, _) => Monad[M].pure(())
+
+  private[retry] def applyPolicy[M[_]: Monad](
+    policy:      RetryPolicy[M],
+    retryStatus: RetryStatus,
+  ): M[NextStep] =
+    policy.decideNextRetry(retryStatus).map {
+      case PolicyDecision.DelayAndRetry(delay) =>
+        NextStep.RetryAfterDelay(delay, retryStatus.addRetry(delay))
+      case PolicyDecision.GiveUp               =>
+        NextStep.GiveUp
+    }
+
+  private[retry] def buildRetryDetails(
+    currentStatus: RetryStatus,
+    nextStep:      NextStep,
+  ): RetryDetails =
+    nextStep match {
+      case NextStep.RetryAfterDelay(delay, _) =>
+        RetryDetails.WillDelayAndRetry(
+          delay,
+          currentStatus.retriesSoFar,
+          currentStatus.cumulativeDelay,
+        )
+      case NextStep.GiveUp                    =>
+        RetryDetails.GivingUp(
+          currentStatus.retriesSoFar,
+          currentStatus.cumulativeDelay,
+        )
+    }
+
+  sealed private[retry] trait NextStep
+
+  private[retry] object NextStep {
+    case object GiveUp extends NextStep
+
+    final case class RetryAfterDelay(
+      delay:         FiniteDuration,
+      updatedStatus: RetryStatus,
+    ) extends NextStep
+  }
+}

--- a/effects-cats/shared/src/main/scala/busymachines/pureharm/effects/PureharmEffectsAliases.scala
+++ b/effects-cats/shared/src/main/scala/busymachines/pureharm/effects/PureharmEffectsAliases.scala
@@ -25,4 +25,5 @@ trait PureharmEffectsAliases
   with aliases.ScalaStdAliases
   with aliases.CatsEffectAliases
   with aliases.Fs2Aliases
+  with aliases.RetryAliases
 // format: on

--- a/effects-cats/shared/src/main/scala/busymachines/pureharm/effects/aliases/CatsEffectAliases.scala
+++ b/effects-cats/shared/src/main/scala/busymachines/pureharm/effects/aliases/CatsEffectAliases.scala
@@ -130,6 +130,9 @@ trait CatsEffectAliases {
   type Console[F[_]] = ce.std.Console[F]
   val Console: ce.std.Console.type = ce.std.Console
 
+  type Backpressure[F[_]] = ce.std.Backpressure[F]
+  val Backpressure: ce.std.Backpressure.type = ce.std.Backpressure
+
   type Semaphore[F[_]] = ce.std.Semaphore[F]
   val Semaphore: ce.std.Semaphore.type = ce.std.Semaphore
 

--- a/effects-cats/shared/src/main/scala/busymachines/pureharm/effects/aliases/CatsSyntax.scala
+++ b/effects-cats/shared/src/main/scala/busymachines/pureharm/effects/aliases/CatsSyntax.scala
@@ -21,6 +21,7 @@ import cats.syntax
 // format: off
 trait CatsSyntax
   extends cats.effect.syntax.AllSyntax
+  with cats.effect.std.syntax.AllSyntax
   with syntax.AllSyntax
   with syntax.AllSyntaxBinCompat0
   with syntax.AllSyntaxBinCompat1

--- a/effects-cats/shared/src/main/scala/busymachines/pureharm/effects/aliases/RetryAliases.scala
+++ b/effects-cats/shared/src/main/scala/busymachines/pureharm/effects/aliases/RetryAliases.scala
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2019 BusyMachines
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package busymachines.pureharm.effects.aliases
+
+trait RetryAliases {
+  type PolicyDecision = busymachines.pureharm.retry.PolicyDecision
+  val PolicyDecision: busymachines.pureharm.retry.PolicyDecision.type = busymachines.pureharm.retry.PolicyDecision
+
+  type RetryPolicy[M[_]] = busymachines.pureharm.retry.RetryPolicy[M]
+  val RetryPolicy: busymachines.pureharm.retry.RetryPolicy.type = busymachines.pureharm.retry.RetryPolicy
+
+  val RetryPolicies: busymachines.pureharm.retry.RetryPolicies.type = busymachines.pureharm.retry.RetryPolicies
+
+  type RetryStatus = busymachines.pureharm.retry.RetryStatus
+  val RetryStatus: busymachines.pureharm.retry.RetryStatus.type = busymachines.pureharm.retry.RetryStatus
+
+  type RetryDetails = busymachines.pureharm.retry.RetryDetails
+  val RetryDetails: busymachines.pureharm.retry.RetryDetails.type = busymachines.pureharm.retry.RetryDetails
+
+  type Sleep[M[_]] = busymachines.pureharm.retry.Sleep[M]
+  val Sleep: busymachines.pureharm.retry.Sleep.type = busymachines.pureharm.retry.Sleep
+}

--- a/effects-cats/shared/src/main/scala/busymachines/pureharm/effects/internals/PureharmSyntax.scala
+++ b/effects-cats/shared/src/main/scala/busymachines/pureharm/effects/internals/PureharmSyntax.scala
@@ -467,7 +467,7 @@ object PureharmSyntax {
       * @return
       *   Never fails and captures the failure of the ``fa`` within the Attempt, times both success and failure case.
       */
-    @scala.deprecated("Use a combination of attempt + .timed from cats-effect", "0.5.0")
+    @scala.deprecated("Use .attempt.timedIn(TimeUnit), or .attempt.timed to default to nanoseconds", "0.5.0")
     def timedAttempt(
       unit:       TimeUnit = MILLISECONDS
     )(implicit F: Temporal[F]): F[(FiniteDuration, Attempt[A])] =
@@ -487,7 +487,10 @@ object PureharmSyntax {
       *   Never fails and captures the failure of the ``fa`` within the Attempt, times all successes and failures, and
       *   returns their sum. N.B. It only captures the latest failure, if it encounters one.
       */
-    @scala.deprecated("Use a combination of cats-retry + .timed from cats-effect", "0.5.0")
+    @scala.deprecated(
+      "Use .retryingOnAllErrors(...).attempt.timedIn(TimeUnit), or retryingOnAllErrors(...).attempt.timed to default to nanoseconds. N.B there exists more retry methods now, where you can specify which errors to recover from. See cats-retry documentation",
+      "0.5.0",
+    )
     def timedReattempt(
       errorLog:       (Throwable, String) => F[Unit],
       timeUnit:       TimeUnit,
@@ -501,7 +504,10 @@ object PureharmSyntax {
 
     /** Same as overload timedReattempt, but does not report any failures.
       */
-    @scala.deprecated("Use a combination of cats-retry + .timed from cats-effect", "0.5.0")
+    @scala.deprecated(
+      "Use .retryingOnAllErrors(...).attempt.timedIn(TimeUnit), or retryingOnAllErrors(...).attempt.timed to default to nanoseconds. N.B there exists more retry methods now, where you can specify which errors to recover from. See cats-retry documentation",
+      "0.5.0",
+    )
     def timedReattempt(
       timeUnit:       TimeUnit
     )(
@@ -524,7 +530,10 @@ object PureharmSyntax {
       * @return
       *   N.B. It only captures the latest failure, if it encounters one.
       */
-    @scala.deprecated("Use retry from cats-retry", "0.5.0")
+    @scala.deprecated(
+      "Use .retryingOnAllErrors(...).attempt. N.B there exists more retry methods now, where you can specify which errors to recover from. See cats-retry documentation",
+      "0.5.0",
+    )
     def reattempt(
       errorLog:       (Throwable, String) => F[Unit]
     )(
@@ -537,7 +546,10 @@ object PureharmSyntax {
 
     /** Same semantics as overload reattempt but does not report any error
       */
-    @scala.deprecated("Use retry from cats-retry", "0.5.0")
+    @scala.deprecated(
+      "Use .retryingOnAllErrors(...).attempt. N.B there exists more retry methods now, where you can specify which errors to recover from. See cats-retry documentation",
+      "0.5.0",
+    )
     def reattempt(
       retries:        Int,
       betweenRetries: FiniteDuration,
@@ -557,7 +569,7 @@ object PureharmSyntax {
       * @return
       *   Never fails and captures the failure of the ``fa`` within the Attempt, times both success and failure case.
       */
-    @scala.deprecated("Use a combination of attempt + .timed from cats-effect", "0.5.0")
+    @scala.deprecated("Use .attempt.timedIn(TimeUnit), or .attempt.timed to default to nanoseconds", "0.5.0")
     def timedAttempt[F[_], A](
       timeUnit:   TimeUnit
     )(
@@ -584,7 +596,10 @@ object PureharmSyntax {
       *   Never fails and captures the failure of the ``fa`` within the Attempt, times all successes and failures, and
       *   returns their sum. N.B. It only captures the latest failure, if it encounters one.
       */
-    @scala.deprecated("Use a combination of cats-retry + .timed from cats-effect", "0.5.0")
+    @scala.deprecated(
+      "Use .retryingOnAllErrors(...).attempt.timedIn(TimeUnit), or retryingOnAllErrors(...).attempt.timed to default to nanoseconds. N.B there exists more retry methods now, where you can specify which errors to recover from. See cats-retry documentation",
+      "0.5.0",
+    )
     def timedReattempt[F[_]: Temporal, A](
       errorLog:       (Throwable, String) => F[Unit],
       timeUnit:       TimeUnit,
@@ -632,7 +647,10 @@ object PureharmSyntax {
       * @return
       *   N.B. It only captures the latest failure, if it encounters one.
       */
-    @scala.deprecated("Use a cats-retry", "0.5.0")
+    @scala.deprecated(
+      "Use .retryingOnAllErrors(...).attempt, or retryingOnAllErrors(...).attempt. N.B there exists more retry methods now, where you can specify which errors to recover from. See cats-retry documentation",
+      "0.5.0",
+    )
     def reattempt[F[_]: Temporal, A](
       errorLog:       (Throwable, String) => F[Unit]
     )(
@@ -645,7 +663,7 @@ object PureharmSyntax {
 
     /** Same semantics as overload reattempt but does not report any error
       */
-    @scala.deprecated("Use a cats-retry", "0.5.0")
+    @scala.deprecated("Use .retryingOnFailures", "0.5.0")
     def reattempt[F[_]: Temporal, A](
       retries:        Int,
       betweenRetries: FiniteDuration,

--- a/effects-cats/shared/src/main/scala/busymachines/pureharm/effects/internals/PureharmSyntax.scala
+++ b/effects-cats/shared/src/main/scala/busymachines/pureharm/effects/internals/PureharmSyntax.scala
@@ -149,6 +149,19 @@ object PureharmSyntax {
         case NonFatal(e) => UnhandledCatastrophe(e): AnomalyLike
       })
 
+    /** .timedIn(scala.concurent.duration.NANOSECONDS) is equivalent to .timed (from cats-effect 3 syntax)
+      *
+      * @param timeUnit
+      *   default value is MILLISECONDS
+      */
+    def timedIn(timeUnit: TimeUnit = MILLISECONDS)(implicit F: Monad[F], clock: Clock[F]): F[(FiniteDuration, A)] =
+      for {
+        start <- clock.monotonic
+        r     <- fa
+        end   <- clock.monotonic
+        dur = end - start
+      } yield (FiniteDuration(dur.toUnit(timeUnit).round, timeUnit), r)
+
   }
 
   //--------------------------- OPTION ---------------------------

--- a/effects-cats/shared/src/main/scala/busymachines/pureharm/retry/Fibonacci.scala
+++ b/effects-cats/shared/src/main/scala/busymachines/pureharm/retry/Fibonacci.scala
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2021 Chris Birchall et. co, contributors of cats-retry
+ * https://github.com/cb372/cats-retry
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package busymachines.pureharm.retry
+
+object Fibonacci {
+
+  def fibonacci(n: Int): Long =
+    if (n > 0)
+      fib(n)._1
+    else
+      0
+
+  // "Fast doubling" Fibonacci algorithm.
+  // See e.g. http://funloop.org/post/2017-04-14-computing-fibonacci-numbers.html for explanation.
+  private def fib(n: Int): (Long, Long) = n match {
+    case 0 => (0, 1)
+    case m =>
+      val (a, b) = fib(m / 2)
+      val c      = a * (b * 2 - a)
+      val d      = a * a + b * b
+      if (n % 2 == 0)
+        (c, d)
+      else
+        (d, c + d)
+  }
+}

--- a/effects-cats/shared/src/main/scala/busymachines/pureharm/retry/PolicyDecision.scala
+++ b/effects-cats/shared/src/main/scala/busymachines/pureharm/retry/PolicyDecision.scala
@@ -1,5 +1,6 @@
 /*
- * Copyright 2019 BusyMachines
+ * Copyright 2021 Chris Birchall et. co, contributors of cats-retry
+ * https://github.com/cb372/cats-retry
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,17 +14,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package busymachines.pureharm.retry
 
-package busymachines.pureharm.effects
+import scala.concurrent.duration.FiniteDuration
 
-import busymachines.pureharm.effects.aliases
+sealed trait PolicyDecision
 
-// format: off
-trait PureharmEffectsAliases
-  extends aliases.PureharmEffectsTypeDefinitions
-  with aliases.CatsAliases
-  with aliases.ScalaStdAliases
-  with aliases.CatsEffectAliases
-  with aliases.Fs2Aliases
-  with aliases.RetryAliases
-// format: on
+object PolicyDecision {
+  case object GiveUp extends PolicyDecision
+
+  final case class DelayAndRetry(
+    delay: FiniteDuration
+  ) extends PolicyDecision
+}

--- a/effects-cats/shared/src/main/scala/busymachines/pureharm/retry/RetryDetails.scala
+++ b/effects-cats/shared/src/main/scala/busymachines/pureharm/retry/RetryDetails.scala
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2021 Chris Birchall et. co, contributors of cats-retry
+ * https://github.com/cb372/cats-retry
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package busymachines.pureharm.retry
+
+import scala.concurrent.duration.FiniteDuration
+
+sealed trait RetryDetails {
+  def retriesSoFar:    Int
+  def cumulativeDelay: FiniteDuration
+  def givingUp:        Boolean
+  def upcomingDelay:   Option[FiniteDuration]
+}
+
+object RetryDetails {
+
+  final case class GivingUp(
+    totalRetries: Int,
+    totalDelay:   FiniteDuration,
+  ) extends RetryDetails {
+    val retriesSoFar:    Int                    = totalRetries
+    val cumulativeDelay: FiniteDuration         = totalDelay
+    val givingUp:        Boolean                = true
+    val upcomingDelay:   Option[FiniteDuration] = None
+  }
+
+  final case class WillDelayAndRetry(
+    nextDelay:       FiniteDuration,
+    retriesSoFar:    Int,
+    cumulativeDelay: FiniteDuration,
+  ) extends RetryDetails {
+    val givingUp:      Boolean                = false
+    val upcomingDelay: Option[FiniteDuration] = Some(nextDelay)
+  }
+}

--- a/effects-cats/shared/src/main/scala/busymachines/pureharm/retry/RetryPolicies.scala
+++ b/effects-cats/shared/src/main/scala/busymachines/pureharm/retry/RetryPolicies.scala
@@ -1,0 +1,170 @@
+/*
+ * Copyright 2021 Chris Birchall et. co, contributors of cats-retry
+ * https://github.com/cb372/cats-retry
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package busymachines.pureharm.retry
+
+import java.util.concurrent.TimeUnit
+
+import cats.Applicative
+import cats.syntax.functor._
+import cats.syntax.show._
+import busymachines.pureharm.retry.PolicyDecision._
+
+import scala.concurrent.duration.{Duration, FiniteDuration}
+import scala.util.Random
+
+object RetryPolicies {
+  private val LongMax: BigInt = BigInt(Long.MaxValue)
+
+  /*
+   * Multiply the given duration by the given multiplier, but cap the result to
+   * ensure we don't try to create a FiniteDuration longer than 2^63 - 1 nanoseconds.
+   *
+   * Note: despite the "safe" in the name, we can still create an invalid
+   * FiniteDuration if the multiplier is negative. But an assumption of the library
+   * as a whole is that nobody would be silly enough to use negative delays.
+   */
+  private def safeMultiply(
+    duration:   FiniteDuration,
+    multiplier: Long,
+  ): FiniteDuration = {
+    val durationNanos   = BigInt(duration.toNanos)
+    val resultNanos     = durationNanos * BigInt(multiplier)
+    val safeResultNanos = resultNanos.min(LongMax)
+    FiniteDuration(safeResultNanos.toLong, TimeUnit.NANOSECONDS)
+  }
+
+  /** Don't retry at all and always give up. Only really useful for combining with other policies.
+    */
+  def alwaysGiveUp[M[_]: Applicative]: RetryPolicy[M] =
+    RetryPolicy.liftWithShow(Function.const(GiveUp), "alwaysGiveUp")
+
+  /** Delay by a constant amount before each retry. Never give up.
+    */
+  def constantDelay[M[_]: Applicative](delay: FiniteDuration): RetryPolicy[M] =
+    RetryPolicy.liftWithShow(
+      Function.const(DelayAndRetry(delay)),
+      show"constantDelay($delay)",
+    )
+
+  /** Each delay is twice as long as the previous one. Never give up.
+    */
+  def exponentialBackoff[M[_]: Applicative](
+    baseDelay: FiniteDuration
+  ): RetryPolicy[M] =
+    RetryPolicy.liftWithShow(
+      { status =>
+        val delay =
+          safeMultiply(baseDelay, Math.pow(2, status.retriesSoFar.toDouble).toLong)
+        DelayAndRetry(delay)
+      },
+      show"exponentialBackOff(baseDelay=$baseDelay)",
+    )
+
+  /** Retry without delay, giving up after the given number of retries.
+    */
+  def limitRetries[M[_]: Applicative](maxRetries: Int): RetryPolicy[M] =
+    RetryPolicy.liftWithShow(
+      status =>
+        if (status.retriesSoFar >= maxRetries) {
+          GiveUp
+        }
+        else {
+          DelayAndRetry(Duration.Zero)
+        },
+      show"limitRetries(maxRetries=$maxRetries)",
+    )
+
+  /** Delay(n) = Delay(n - 2) + Delay(n - 1)
+    *
+    * e.g. if `baseDelay` is 10 milliseconds, the delays before each retry will be 10 ms, 10 ms, 20 ms, 30ms, 50ms,
+    * 80ms, 130ms, ...
+    */
+  def fibonacciBackoff[M[_]: Applicative](
+    baseDelay: FiniteDuration
+  ): RetryPolicy[M] =
+    RetryPolicy.liftWithShow(
+      { status =>
+        val delay =
+          safeMultiply(baseDelay, Fibonacci.fibonacci(status.retriesSoFar + 1))
+        DelayAndRetry(delay)
+      },
+      show"fibonacciBackoff(baseDelay=$baseDelay)",
+    )
+
+  /** "Full jitter" backoff algorithm. See https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/
+    */
+  def fullJitter[M[_]: Applicative](baseDelay: FiniteDuration): RetryPolicy[M] =
+    RetryPolicy.liftWithShow(
+      { status =>
+        val e          = Math.pow(2, status.retriesSoFar.toDouble).toLong
+        val maxDelay   = safeMultiply(baseDelay, e)
+        val delayNanos = (maxDelay.toNanos * Random.nextDouble()).toLong
+        DelayAndRetry(new FiniteDuration(delayNanos, TimeUnit.NANOSECONDS))
+      },
+      show"fullJitter(baseDelay=$baseDelay)",
+    )
+
+  /** Set an upper bound on any individual delay produced by the given policy.
+    */
+  def capDelay[M[_]: Applicative](
+    cap:    FiniteDuration,
+    policy: RetryPolicy[M],
+  ): RetryPolicy[M] =
+    policy.meet(constantDelay(cap))
+
+  /** Add an upper bound to a policy such that once the given time-delay amount <b>per try</b> has been reached or
+    * exceeded, the policy will stop retrying and give up. If you need to stop retrying once <b>cumulative</b> delay
+    * reaches a time-delay amount, use [[limitRetriesByCumulativeDelay]].
+    */
+  def limitRetriesByDelay[M[_]: Applicative](
+    threshold: FiniteDuration,
+    policy:    RetryPolicy[M],
+  ): RetryPolicy[M] = {
+    def decideNextRetry(status: RetryStatus): M[PolicyDecision] =
+      policy.decideNextRetry(status).map {
+        case r @ DelayAndRetry(delay) =>
+          if (delay > threshold) GiveUp else r
+        case GiveUp                   => GiveUp
+      }
+
+    RetryPolicy.withShow[M](
+      decideNextRetry,
+      show"limitRetriesByDelay(threshold=$threshold, $policy)",
+    )
+  }
+
+  /** Add an upperbound to a policy such that once the cumulative delay over all retries has reached or exceeded the
+    * given limit, the policy will stop retrying and give up.
+    */
+  def limitRetriesByCumulativeDelay[M[_]: Applicative](
+    threshold: FiniteDuration,
+    policy:    RetryPolicy[M],
+  ): RetryPolicy[M] = {
+    def decideNextRetry(status: RetryStatus): M[PolicyDecision] =
+      policy.decideNextRetry(status).map {
+        case r @ DelayAndRetry(delay) =>
+          if (status.cumulativeDelay + delay >= threshold) GiveUp else r
+        case GiveUp                   => GiveUp
+      }
+
+    RetryPolicy.withShow[M](
+      decideNextRetry,
+      show"limitRetriesByCumulativeDelay(threshold=$threshold, $policy)",
+    )
+  }
+}

--- a/effects-cats/shared/src/main/scala/busymachines/pureharm/retry/RetryPolicy.scala
+++ b/effects-cats/shared/src/main/scala/busymachines/pureharm/retry/RetryPolicy.scala
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2021 Chris Birchall et. co, contributors of cats-retry
+ * https://github.com/cb372/cats-retry
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package busymachines.pureharm.retry
+
+import cats.{Apply, Applicative, Monad, Functor}
+import cats.kernel.BoundedSemilattice
+import busymachines.pureharm.retry.PolicyDecision._
+
+import scala.concurrent.duration.Duration
+import scala.concurrent.duration.FiniteDuration
+import cats.arrow.FunctionK
+import cats.implicits._
+import cats.Show
+
+case class RetryPolicy[M[_]](
+  decideNextRetry: RetryStatus => M[PolicyDecision]
+) {
+  def show: String = toString
+
+  def followedBy(rp: RetryPolicy[M])(implicit M: Apply[M]): RetryPolicy[M] =
+    RetryPolicy.withShow(
+      status =>
+        M.map2(decideNextRetry(status), rp.decideNextRetry(status)) {
+          case (GiveUp, pd) => pd
+          case (pd, _)      => pd
+        },
+      show"$show.followedBy($rp)",
+    )
+
+  /** Combine this schedule with another schedule, giving up when either of the schedules want to give up and choosing
+    * the maximum of the two delays when both of the schedules want to delay the next retry. The dual of the `meet`
+    * operation.
+    */
+  def join(rp: RetryPolicy[M])(implicit M: Apply[M]): RetryPolicy[M] =
+    RetryPolicy.withShow[M](
+      status =>
+        M.map2(decideNextRetry(status), rp.decideNextRetry(status)) {
+          case (DelayAndRetry(a), DelayAndRetry(b)) => DelayAndRetry(a.max(b))
+          case _                                    => GiveUp
+        },
+      show"$show.join($rp)",
+    )
+
+  /** Combine this schedule with another schedule, giving up when both of the schedules want to give up and choosing the
+    * minimum of the two delays when both of the schedules want to delay the next retry. The dual of the `join`
+    * operation.
+    */
+  def meet(rp: RetryPolicy[M])(implicit M: Apply[M]): RetryPolicy[M] =
+    RetryPolicy.withShow[M](
+      status =>
+        M.map2(decideNextRetry(status), rp.decideNextRetry(status)) {
+          case (DelayAndRetry(a), DelayAndRetry(b)) => DelayAndRetry(a.min(b))
+          case (s @ DelayAndRetry(_), GiveUp)       => s
+          case (GiveUp, s @ DelayAndRetry(_))       => s
+          case _                                    => GiveUp
+        },
+      show"$show.meet($rp)",
+    )
+
+  def mapDelay(
+    f:          FiniteDuration => FiniteDuration
+  )(implicit M: Functor[M]): RetryPolicy[M] =
+    RetryPolicy.withShow(
+      status =>
+        M.map(decideNextRetry(status)) {
+          case GiveUp           => GiveUp
+          case DelayAndRetry(d) => DelayAndRetry(f(d))
+        },
+      show"$show.mapDelay(<function>)",
+    )
+
+  def flatMapDelay(
+    f:          FiniteDuration => M[FiniteDuration]
+  )(implicit M: Monad[M]): RetryPolicy[M] =
+    RetryPolicy.withShow(
+      status =>
+        M.flatMap(decideNextRetry(status)) {
+          case GiveUp           => M.pure(GiveUp)
+          case DelayAndRetry(d) => M.map(f(d))(DelayAndRetry(_))
+        },
+      show"$show.flatMapDelay(<function>)",
+    )
+
+  def mapK[N[_]](nt: FunctionK[M, N]): RetryPolicy[N] =
+    RetryPolicy.withShow(
+      status => nt(decideNextRetry(status)),
+      show"$show.mapK(<FunctionK>)",
+    )
+}
+
+object RetryPolicy {
+
+  def lift[M[_]](
+    f: RetryStatus => PolicyDecision
+  )(implicit
+    M: Applicative[M]
+  ): RetryPolicy[M] =
+    RetryPolicy[M](decideNextRetry = retryStatus => M.pure(f(retryStatus)))
+
+  def withShow[M[_]](
+    decideNextRetry: RetryStatus => M[PolicyDecision],
+    pretty: => String,
+  ): RetryPolicy[M] =
+    new RetryPolicy[M](decideNextRetry) {
+      override def show:     String = pretty
+      override def toString: String = pretty
+    }
+
+  def liftWithShow[M[_]: Applicative](
+    decideNextRetry: RetryStatus => PolicyDecision,
+    pretty:          => String,
+  ): RetryPolicy[M] =
+    withShow(rs => Applicative[M].pure(decideNextRetry(rs)), pretty)
+
+  implicit def boundedSemilatticeForRetryPolicy[M[_]](implicit
+    M: Applicative[M]
+  ): BoundedSemilattice[RetryPolicy[M]] =
+    new BoundedSemilattice[RetryPolicy[M]] {
+
+      override def empty: RetryPolicy[M] =
+        RetryPolicies.constantDelay[M](Duration.Zero)
+
+      override def combine(
+        x: RetryPolicy[M],
+        y: RetryPolicy[M],
+      ): RetryPolicy[M] = x.join(y)
+    }
+
+  implicit def showForRetryPolicy[M[_]]: Show[RetryPolicy[M]] =
+    Show.show(_.show)
+}

--- a/effects-cats/shared/src/main/scala/busymachines/pureharm/retry/RetryStatus.scala
+++ b/effects-cats/shared/src/main/scala/busymachines/pureharm/retry/RetryStatus.scala
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2021 Chris Birchall et. co, contributors of cats-retry
+ * https://github.com/cb372/cats-retry
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package busymachines.pureharm.retry
+
+import scala.concurrent.duration.{Duration, FiniteDuration}
+
+final case class RetryStatus(
+  retriesSoFar:    Int,
+  cumulativeDelay: FiniteDuration,
+  previousDelay:   Option[FiniteDuration],
+) {
+
+  def addRetry(delay: FiniteDuration): RetryStatus = RetryStatus(
+    retriesSoFar    = this.retriesSoFar + 1,
+    cumulativeDelay = this.cumulativeDelay + delay,
+    previousDelay   = Some(delay),
+  )
+}
+
+object RetryStatus {
+  val NoRetriesYet = RetryStatus(0, Duration.Zero, None)
+}

--- a/effects-cats/shared/src/main/scala/busymachines/pureharm/retry/Sleep.scala
+++ b/effects-cats/shared/src/main/scala/busymachines/pureharm/retry/Sleep.scala
@@ -1,5 +1,6 @@
 /*
- * Copyright 2019 BusyMachines
+ * Copyright 2021 Chris Birchall et. co, contributors of cats-retry
+ * https://github.com/cb372/cats-retry
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,16 +15,19 @@
  * limitations under the License.
  */
 
-package busymachines.pureharm.effects
+package busymachines.pureharm.retry
 
-import busymachines.pureharm.effects.aliases
+import cats.effect.Temporal
 
-// format: off
-trait PureharmEffectsAliases
-  extends aliases.PureharmEffectsTypeDefinitions
-  with aliases.CatsAliases
-  with aliases.ScalaStdAliases
-  with aliases.CatsEffectAliases
-  with aliases.Fs2Aliases
-  with aliases.RetryAliases
-// format: on
+import scala.concurrent.duration.FiniteDuration
+
+trait Sleep[M[_]] {
+  def sleep(delay: FiniteDuration): M[Unit]
+}
+
+object Sleep {
+  def apply[M[_]](implicit sleep: Sleep[M]): Sleep[M] = sleep
+
+  implicit def sleepUsingTemporal[F[_]](implicit t: Temporal[F]): Sleep[F] =
+    (delay: FiniteDuration) => t.sleep(delay)
+}

--- a/effects-cats/shared/src/main/scala/busymachines/pureharm/retry/retryOps.scala
+++ b/effects-cats/shared/src/main/scala/busymachines/pureharm/retry/retryOps.scala
@@ -1,0 +1,250 @@
+/*
+ * Copyright 2019 BusyMachines
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package busymachines.pureharm.retry
+
+import cats.{Monad, MonadError}
+import cats.syntax.apply._
+import cats.syntax.functor._
+import cats.syntax.flatMap._
+
+import scala.concurrent.duration.FiniteDuration
+
+object retryOps {
+  def retryingOnFailures[A] = new RetryingOnFailuresPartiallyApplied[A]
+
+  private def retryingOnFailuresImpl[M[_], A](
+    policy:        RetryPolicy[M],
+    wasSuccessful: A => M[Boolean],
+    onFailure:     (A, RetryDetails) => M[Unit],
+    status:        RetryStatus,
+    a:             A,
+  )(implicit
+    M:             Monad[M],
+    S:             Sleep[M],
+  ): M[Either[RetryStatus, A]] = {
+
+    def onFalse: M[Either[RetryStatus, A]] = for {
+      nextStep <- applyPolicy(policy, status)
+      _        <- onFailure(a, buildRetryDetails(status, nextStep))
+      result   <- nextStep match {
+        case NextStep.RetryAfterDelay(delay, updatedStatus) =>
+          S.sleep(delay) *>
+            M.pure(Left(updatedStatus)) // continue recursion
+        case NextStep.GiveUp =>
+          M.pure(Right(a)) // stop the recursion
+      }
+    } yield result
+
+    wasSuccessful(a).ifM(
+      M.pure(Right(a)), // stop the recursion
+      onFalse,
+    )
+  }
+
+  private[retry] class RetryingOnFailuresPartiallyApplied[A] {
+
+    def apply[M[_]](
+      policy:        RetryPolicy[M],
+      wasSuccessful: A => M[Boolean],
+      onFailure:     (A, RetryDetails) => M[Unit],
+    )(
+      action:        => M[A]
+    )(implicit
+      M:             Monad[M],
+      S:             Sleep[M],
+    ): M[A] = M.tailRecM(RetryStatus.NoRetriesYet) { status =>
+      action.flatMap(a => retryingOnFailuresImpl(policy, wasSuccessful, onFailure, status, a))
+    }
+  }
+
+  def retryingOnSomeErrors[A] = new RetryingOnSomeErrorsPartiallyApplied[A]
+
+  private def retryingOnSomeErrorsImpl[M[_], A, E](
+    policy:          RetryPolicy[M],
+    isWorthRetrying: E => M[Boolean],
+    onError:         (E, RetryDetails) => M[Unit],
+    status:          RetryStatus,
+    attempt:         Either[E, A],
+  )(implicit
+    ME:              MonadError[M, E],
+    S:               Sleep[M],
+  ): M[Either[RetryStatus, A]] = attempt match {
+    case Left(error)    =>
+      isWorthRetrying(error).ifM(
+        for {
+          nextStep <- applyPolicy(policy, status)
+          _        <- onError(error, buildRetryDetails(status, nextStep))
+          result   <- nextStep match {
+            case NextStep.RetryAfterDelay(delay, updatedStatus) =>
+              S.sleep(delay) *>
+                ME.pure(Left(updatedStatus)) // continue recursion
+            case NextStep.GiveUp =>
+              ME.raiseError[A](error).map(Right(_)) // stop the recursion
+          }
+        } yield result,
+        ME.raiseError[A](error).map(Right(_)), // stop the recursion
+      )
+    case Right(success) =>
+      ME.pure(Right(success)) // stop the recursion
+  }
+
+  private[retry] class RetryingOnSomeErrorsPartiallyApplied[A] {
+
+    def apply[M[_], E](
+      policy:          RetryPolicy[M],
+      isWorthRetrying: E => M[Boolean],
+      onError:         (E, RetryDetails) => M[Unit],
+    )(
+      action:          => M[A]
+    )(implicit
+      ME:              MonadError[M, E],
+      S:               Sleep[M],
+    ): M[A] = ME.tailRecM(RetryStatus.NoRetriesYet) { status =>
+      ME.attempt(action).flatMap { attempt =>
+        retryingOnSomeErrorsImpl(
+          policy,
+          isWorthRetrying,
+          onError,
+          status,
+          attempt,
+        )
+      }
+    }
+  }
+
+  def retryingOnAllErrors[A] = new RetryingOnAllErrorsPartiallyApplied[A]
+
+  private[retry] class RetryingOnAllErrorsPartiallyApplied[A] {
+
+    def apply[M[_], E](
+      policy:  RetryPolicy[M],
+      onError: (E, RetryDetails) => M[Unit],
+    )(
+      action:  => M[A]
+    )(implicit
+      ME:      MonadError[M, E],
+      S:       Sleep[M],
+    ): M[A] =
+      retryingOnSomeErrors[A].apply[M, E](policy, _ => ME.pure(true), onError)(
+        action
+      )
+  }
+
+  def retryingOnFailuresAndSomeErrors[A] =
+    new RetryingOnFailuresAndSomeErrorsPartiallyApplied[A]
+
+  private[retry] class RetryingOnFailuresAndSomeErrorsPartiallyApplied[A] {
+
+    def apply[M[_], E](
+      policy:          RetryPolicy[M],
+      wasSuccessful:   A => M[Boolean],
+      isWorthRetrying: E => M[Boolean],
+      onFailure:       (A, RetryDetails) => M[Unit],
+      onError:         (E, RetryDetails) => M[Unit],
+    )(
+      action:          => M[A]
+    )(implicit
+      ME:              MonadError[M, E],
+      S:               Sleep[M],
+    ): M[A] =
+      ME.tailRecM(RetryStatus.NoRetriesYet) { status =>
+        ME.attempt(action).flatMap {
+          case Right(a) =>
+            retryingOnFailuresImpl(policy, wasSuccessful, onFailure, status, a)
+          case attempt  =>
+            retryingOnSomeErrorsImpl(
+              policy,
+              isWorthRetrying,
+              onError,
+              status,
+              attempt,
+            )
+        }
+      }
+  }
+
+  def retryingOnFailuresAndAllErrors[A] =
+    new RetryingOnFailuresAndAllErrorsPartiallyApplied[A]
+
+  private[retry] class RetryingOnFailuresAndAllErrorsPartiallyApplied[A] {
+
+    def apply[M[_], E](
+      policy:        RetryPolicy[M],
+      wasSuccessful: A => M[Boolean],
+      onFailure:     (A, RetryDetails) => M[Unit],
+      onError:       (E, RetryDetails) => M[Unit],
+    )(
+      action:        => M[A]
+    )(implicit
+      ME:            MonadError[M, E],
+      S:             Sleep[M],
+    ): M[A] =
+      retryingOnFailuresAndSomeErrors[A]
+        .apply[M, E](
+          policy,
+          wasSuccessful,
+          _ => ME.pure(true),
+          onFailure,
+          onError,
+        )(
+          action
+        )
+  }
+
+  def noop[M[_]: Monad, A]: (A, RetryDetails) => M[Unit] =
+    (_, _) => Monad[M].pure(())
+
+  private[retry] def applyPolicy[M[_]: Monad](
+    policy:      RetryPolicy[M],
+    retryStatus: RetryStatus,
+  ): M[NextStep] =
+    policy.decideNextRetry(retryStatus).map {
+      case PolicyDecision.DelayAndRetry(delay) =>
+        NextStep.RetryAfterDelay(delay, retryStatus.addRetry(delay))
+      case PolicyDecision.GiveUp               =>
+        NextStep.GiveUp
+    }
+
+  private[retry] def buildRetryDetails(
+    currentStatus: RetryStatus,
+    nextStep:      NextStep,
+  ): RetryDetails =
+    nextStep match {
+      case NextStep.RetryAfterDelay(delay, _) =>
+        RetryDetails.WillDelayAndRetry(
+          delay,
+          currentStatus.retriesSoFar,
+          currentStatus.cumulativeDelay,
+        )
+      case NextStep.GiveUp                    =>
+        RetryDetails.GivingUp(
+          currentStatus.retriesSoFar,
+          currentStatus.cumulativeDelay,
+        )
+    }
+
+  sealed private[retry] trait NextStep
+
+  private[retry] object NextStep {
+    case object GiveUp extends NextStep
+
+    final case class RetryAfterDelay(
+      delay:         FiniteDuration,
+      updatedStatus: RetryStatus,
+    ) extends NextStep
+  }
+}

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,6 @@
 // format: off
-addSbtPlugin("org.scalameta"        % "sbt-scalafmt"             % "2.4.3" )       // https://github.com/scalameta/sbt-scalafmt/releases
-addSbtPlugin("org.scala-js"         % "sbt-scalajs"              % "1.6.0" )       // https://github.com/scala-js/scala-js/releases/
-addSbtPlugin("org.portable-scala"   % "sbt-scalajs-crossproject" % "1.1.0" )       // https://github.com/portable-scala/sbt-crossproject/releases
-addSbtPlugin("com.codecommit"       % "sbt-spiewak-sonatype"     % "0.21.0")       // https://github.com/djspiewak/sbt-spiewak/releases/
-addSbtPlugin("de.heikoseeberger"    % "sbt-header"               % "5.6.0" )       // https://github.com/sbt/sbt-header/releases
+addSbtPlugin("org.scalameta"        % "sbt-scalafmt"                % "2.4.3" )       // https://github.com/scalameta/sbt-scalafmt/releases
+addSbtPlugin("org.scala-js"         % "sbt-scalajs"                 % "1.6.0" )       // https://github.com/scala-js/scala-js/releases/
+addSbtPlugin("org.portable-scala"   % "sbt-scalajs-crossproject"    % "1.1.0" )       // https://github.com/portable-scala/sbt-crossproject/releases
+addSbtPlugin("com.codecommit"       % "sbt-spiewak-sonatype"        % "0.21.0")       // https://github.com/djspiewak/sbt-spiewak/releases/
+addSbtPlugin("de.heikoseeberger"    % "sbt-header"                  % "5.6.0" )       // https://github.com/sbt/sbt-header/releases


### PR DESCRIPTION
[cats-retry](https://github.com/cb372/cats-retry) has proven to be extremely useful, to the point where one barely writes any production apps without it. We integrated it into pureharm, because it currently does not have a Scala 3 release, but will depend on it directly in the future. 